### PR TITLE
feat: 여행 삭제, 유저 승인또는 거부 API 추가 (#22)

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -85,8 +85,20 @@ const TravelSchema: Schema<ITravel> = new Schema(
     reviewWrite: { type: Boolean, default: false },
     isDeleted: { type: Boolean, default: false },
   },
-  { timestamps: true },
+  {
+    timestamps: true,
+    query: {
+      isDeleted: false,
+    },
+  },
 );
+
+TravelSchema.pre(['find', 'findOne'], function (next) {
+  if (!Object.prototype.hasOwnProperty.call(this.getQuery(), 'isDeleted')) {
+    this?.where({ isDeleted: false });
+  }
+  next();
+});
 
 export const Travel = mongoose.model<ITravel>('Travel', TravelSchema);
 


### PR DESCRIPTION
<!-- 변경 사항이나 추가된 기능에 대해 자세히 설명해 주세요. -->
- 여행 승인, 여행 거부, 여행 삭제 기능 추가

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- 수정된 화면이나 기능을 보여주는 스크린샷을 첨부할 수 있습니다. -->

<!-- 추가 정보나 특별한 요청 사항이 있다면 여기에 포함해 주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 여행 항목의 활성 상태를 업데이트하는 새로운 API 엔드포인트 추가 (`PATCH /update-active`).
	- 여행 항목을 삭제하는 새로운 API 엔드포인트 추가 (`PATCH /delete-travel`), 사용자 승인 상태에 따라 삭제 가능 여부 확인.
	- 사용자의 팀 내 상태를 업데이트하는 새로운 API 엔드포인트 추가 (`PATCH /update-user-status`).

- **Bug Fixes**
	- 여행 조회 API에서 응답 상태를 명시적으로 200으로 설정.

- **Chores**
	- 서버의 로깅 및 오류 처리 개선, 서버 종료 절차 간소화.
	- 여행 스키마에 소프트 삭제를 위한 쿼리 필터 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->